### PR TITLE
Add Kg encryption key and privilege level support to IpmiController

### DIFF
--- a/ipmi-server/rootfs/app/src/Controller/IpmiController.php
+++ b/ipmi-server/rootfs/app/src/Controller/IpmiController.php
@@ -189,6 +189,8 @@ class IpmiController
 
         $user = $query->get('user', '');
         $pass = $query->get('password', '');
+        $kg_key = $query->get('kg_key', '');
+        $privilege_level = $query->get('privilege_level', '');
         $extra = $query->get('extra', '');
 
         $cmd = ['ipmitool', '-H', $host, '-p', $query->get('port', self::DEFAULT_PORT)];
@@ -203,8 +205,27 @@ class IpmiController
             $cmd[] = $pass;
         }
 
+        // Add Kg key for encrypted IPMI sessions
+        if (!empty($kg_key)) {
+            $cmd[] = '-y';
+            $cmd[] = $kg_key;
+        }
+
+        // Add privilege level
+        if (!empty($privilege_level)) {
+            $cmd[] = '-L';
+            $cmd[] = $privilege_level;
+        }
+
+        // Parse extra params if provided
         if (!empty($extra)) {
-            $cmd[] = $extra;
+            // If extra contains multiple arguments, parse them properly
+            $extraArgs = str_getcsv($extra, ' ', '"', '');
+            foreach ($extraArgs as $arg) {
+                if (!empty($arg)) {
+                    $cmd[] = $arg;
+                }
+            }
         }
 
         return $cmd;


### PR DESCRIPTION
I ran into a few problems while trying to get the IPMI connector working with my servers:

1. My servers use IPMIv2.0 authentication keys (referred to as Kg keys in the spec). The addon didn't have a field for that, so I had to try putting the hex key in the "extra params" field, which had a parsing error and would fail.

2. The user I was connecting with only had OPERATOR privileges. The addon did not have a means of specifying privileges and defaulted to ADMINISTRATOR (which is typically what we do NOT want to use as it can write raw values to the BMC, giving bad actors the chance to seriously impact systems)

To address those issues, I have made the following changes to the server component:

- Add kg_key parameter support with -y flag for ipmitool
- Add privilege_level parameter support with -L flag for ipmitool
- Improve extra params parsing to properly handle multiple arguments
- Fixes issue where hex keys were being mangled when passed as args

I have these changes running in my personal Home Assistant environment. As far as I can tell, it's running without issues. Figured I'd send those changes back upstream in case anyone else is blocked by the same issues I was.