### PR TITLE
Let nginx also listen IPv6 Port

### DIFF
--- a/ipmi-server/rootfs/etc/nginx/servers/ingress.conf
+++ b/ipmi-server/rootfs/etc/nginx/servers/ingress.conf
@@ -1,5 +1,6 @@
 server {
     listen 8099 default_server;
+    listen [::]:8099 default_server;
 
     root            /dev/null;
     server_name     $hostname;

--- a/ipmi-server/rootfs/etc/nginx/servers/ipmi.conf
+++ b/ipmi-server/rootfs/etc/nginx/servers/ipmi.conf
@@ -1,5 +1,6 @@
 server {
     listen 80 default_server;
+    listen [::]:80 default_server;
 
     root /app/public;
     index index.php;


### PR DESCRIPTION
Nginx not listen IPv6 by default. Homeassistant add-on added port mapping in both ipv4/ipv6.
So, you will get `connection reset by peer` error when `curl [::]:9595`
In newer HomeAssistant OS, `localhost` has been mapped to `[::]` as well. So then you will get same error when `curl localhost:9595`.
[home-assistant-ipmi](https://github.com/ateodorescu/home-assistant-ipmi) will also not work because it also uses `localhost` instead `127.0.0.1` by default.